### PR TITLE
Add `.venv` to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .DS_Store
 src/newsgator/config.py
 newsgator.log
+.venv


### PR DESCRIPTION
### FabGPT — l0-git remediation

**Gate:** `gitignore_coverage` · **Confidence:** deterministic

.gitignore does not cover `.venv`. Python bytecode and virtualenv directories are user-local and should never travel through git. Add `.venv` to your .gitignore.

_Approved by a human before opening._

---
🤖 **FabGPT OS** · source `l0git` · model `deterministic` · task `64ea9a7b47490ccb` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"64ea9a7b47490ccb","source":"l0git","model":"deterministic","severity":"INFO","iterations":1,"inference_s":0.0,"triage":"INFO"} -->