### PR TITLE
Bump requests to 2.33.0 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 feedparser==6.0.10
-requests==2.32.4
+requests==2.33.0
 beautifulsoup4==4.12.2
 scikit-learn==1.5.1
 openai==1.6.0


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `requests` `2.32.4` → `2.33.0`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisory:** Requests has Insecure Temp File Reuse in its extract_zipped_paths() utility function CVE-2026-25645

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `c93077fa0ea9005d` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"c93077fa0ea9005d","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->