### PR TITLE
Bump markdown to 3.8.1 (medium)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ beautifulsoup4==4.12.2
 scikit-learn==1.5.1
 openai==1.6.0
 jinja2==3.1.6
-markdown==3.5
+markdown==3.8.1
 markdown2==2.4.10
 pytest==7.4.3
 rich==13.7.0


### PR DESCRIPTION
### FabGPT — OSV security bump

**Package:** `markdown` `3.5` → `3.8.1`
**Manifest:** `requirements.txt`
**Severity:** medium
**Advisory:** Python-Markdown has an Uncaught Exception CVE-2025-69534

Source: [OSV.dev](https://osv.dev) (deterministic). _Human-approved before opening._

---
🤖 **FabGPT OS** · source `osv` · model `deterministic` · task `aa4e709ca8ea9af1` · HITL-approved before opening.
<!-- fabgpt:{"task_id":"aa4e709ca8ea9af1","source":"osv","model":"deterministic","severity":"WARN","iterations":1,"inference_s":0.0,"triage":"WARN"} -->